### PR TITLE
Add initial dsl support for configuring non-web freemarker

### DIFF
--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/freemarker/FreeMarkerInitializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.freemarker;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.ui.freemarker.FreeMarkerConfigurationFactoryBean;
+
+/**
+ * {@link ApplicationContextInitializer} adapter for {@link FreeMarkerNonWebConfiguration}.
+ * @author Ivan Skachkov
+ */
+public class FreeMarkerInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
+    private FreeMarkerProperties freeMarkerProperties;
+
+    public FreeMarkerInitializer(FreeMarkerProperties freeMarkerProperties) {
+        this.freeMarkerProperties = freeMarkerProperties;
+    }
+
+    @Override
+    public void initialize(GenericApplicationContext applicationContext) {
+        applicationContext.registerBean(FreeMarkerConfigurationFactoryBean.class, () -> new FreeMarkerNonWebConfiguration(freeMarkerProperties).freeMarkerConfiguration());
+    }
+}

--- a/kofu/build.gradle.kts
+++ b/kofu/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 	compileOnly("org.springframework.data:spring-data-redis")
 	compileOnly("com.fasterxml.jackson.core:jackson-databind")
 	compileOnly("com.samskivert:jmustache")
+	compileOnly("org.freemarker:freemarker")
 	compileOnly("io.projectreactor.kotlin:reactor-kotlin-extensions")
 	compileOnly("javax.servlet:javax.servlet-api")
 
@@ -37,6 +38,7 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-undertow")
 	testImplementation("org.springframework.boot:spring-boot-starter-jetty")
 	testImplementation("org.springframework.boot:spring-boot-starter-mustache")
+	testImplementation("org.springframework.boot:spring-boot-starter-freemarker")
 	testImplementation("org.springframework.boot:spring-boot-starter-json")
 	testImplementation("org.springframework.boot:spring-boot-starter-data-mongodb-reactive")
 	testImplementation("org.springframework.boot:spring-boot-starter-data-cassandra-reactive")

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/ConfigurationDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/ConfigurationDsl.kt
@@ -45,8 +45,8 @@ open class ConfigurationDsl(private val dsl: ConfigurationDsl.() -> Unit): Abstr
 	 *
 	 * @sample org.springframework.fu.kofu.samples.configurationProperties
 	 */
-	inline fun <reified T : Any> configurationProperties(properties: T? = null, prefix: String = ""): T {
-		val bindedProperties = properties ?: FunctionalConfigurationPropertiesBinder(context).bind(prefix, Bindable.of(T::class.java)).get()
+	inline fun <reified T : Any> configurationProperties(properties: T? = null, prefix: String = "", defaultProperties: T? = null): T {
+		val bindedProperties = properties ?: FunctionalConfigurationPropertiesBinder(context).bind(prefix, Bindable.of(T::class.java)).orElse(defaultProperties)
 		context.registerBean<T>("${T::class.java.simpleName.toLowerCase()}ConfigurationProperties") {
 			bindedProperties
 		}

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/freemarker/FreeMarkerDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/freemarker/FreeMarkerDsl.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.fu.kofu.freemarker
+
+import org.springframework.boot.autoconfigure.freemarker.FreeMarkerInitializer
+import org.springframework.boot.autoconfigure.freemarker.FreeMarkerProperties
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.fu.kofu.AbstractDsl
+import org.springframework.fu.kofu.ApplicationDsl
+
+/**
+ * Kofu DSL for FreeMarker configuration.
+ *
+ * Configure a [FreeMarker](https://freemarker.apache.org).
+ *
+ * Required dependencies can be retrieve using `org.springframework.boot:spring-boot-starter-freemarker`.
+ * @sample org.springframework.fu.kofu.samples.freeMarkerDsl
+ * @author Ivan Skachkov
+ */
+class FreeMarkerDsl(private val init: FreeMarkerDsl.() -> Unit, private val freemarkerProperties: FreeMarkerProperties = FreeMarkerProperties()) : AbstractDsl() {
+    /**
+     * Comma-separated list of template paths.
+     */
+    var templateLoaderPath: Array<String>
+        get() = freemarkerProperties.templateLoaderPath
+        set(value) {
+            freemarkerProperties.setTemplateLoaderPath(*value)
+        }
+
+    /**
+     * Well-known FreeMarker keys which are passed to FreeMarker's Configuration.
+     */
+    val settings: MutableMap<String, String>
+        get() = freemarkerProperties.settings
+
+    override fun initialize(context: GenericApplicationContext) {
+        super.initialize(context)
+        init()
+        FreeMarkerInitializer(freemarkerProperties).initialize(context)
+    }
+}
+
+/**
+ * Configure a [FreeMarker](https://freemarker.apache.org).
+ *
+ * Configuration from properties / environment (with "spring.freemarker" prefix) is a starting point for further customisation if needed.
+ *
+ * Require `org.springframework.boot:spring-boot-starter-freemarker` dependency.
+ *
+ * @sample org.springframework.fu.kofu.samples.freeMarkerDsl
+ */
+fun ApplicationDsl.freeMarker(dsl: FreeMarkerDsl.() -> Unit = {}) {
+    val freeMarkerProperties = configurationProperties(prefix = "spring.freemarker", defaultProperties = FreeMarkerProperties())
+    FreeMarkerDsl(dsl, freeMarkerProperties).initialize(context)
+}

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/freemarker/FreeMarkerDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/freemarker/FreeMarkerDslTests.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.fu.kofu.freemarker
+
+import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.boot.WebApplicationType
+import org.springframework.fu.kofu.application
+import org.springframework.ui.freemarker.FreeMarkerConfigurationFactoryBean
+import org.springframework.ui.freemarker.FreeMarkerTemplateUtils
+
+/**
+ * @author Ivan Skachkov
+ */
+class FreeMarkerDslTests {
+
+    @Test
+    fun `Use non web FreeMarker to generate content from template`() {
+        val app = application(WebApplicationType.NONE) {
+            beans { bean<FreeMarkerUser>() }
+            freeMarker {
+                templateLoaderPath = arrayOf("classpath:/templates/", "classpath:/templates-2/")
+            }
+        }
+
+        with(app.run()) {
+            val freeMarkerUser = getBean(FreeMarkerUser::class.java)
+            assertEquals(freeMarkerUser.useTemplate(name = "template.ftlh"), "Hello world!")
+            assertEquals(freeMarkerUser.useTemplate(name = "template-2.ftlh"), "Hello world, 2!")
+            close()
+        }
+    }
+}
+
+class FreeMarkerUser(private val templateConfigurationFactory: FreeMarkerConfigurationFactoryBean) {
+    fun useTemplate(name: String) = FreeMarkerTemplateUtils.processTemplateIntoString(
+        templateConfigurationFactory.createConfiguration().getTemplate(name),
+        mapOf("name" to "world")
+    )
+}

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/freemarker.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/freemarker.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.fu.kofu.samples
+
+import org.springframework.boot.WebApplicationType
+import org.springframework.fu.kofu.application
+import org.springframework.fu.kofu.freemarker.freeMarker
+
+/**
+ * @see org.springframework.fu.kofu.webmvc.FreeMarkerDslTests
+ */
+fun freeMarkerDsl() {
+    application(WebApplicationType.NONE) {
+        freeMarker {
+            settings["locale"] = "en_GB" // https://freemarker.apache.org/docs/api/freemarker/template/Configuration.html#setSetting-java.lang.String-java.lang.String-
+            templateLoaderPath = arrayOf("classpath:/templates/", "classpath:/templates-2/")
+        }
+    }
+}

--- a/kofu/src/test/resources/templates-2/template-2.ftlh
+++ b/kofu/src/test/resources/templates-2/template-2.ftlh
@@ -1,0 +1,1 @@
+Hello ${name}, 2!

--- a/kofu/src/test/resources/templates/template.ftlh
+++ b/kofu/src/test/resources/templates/template.ftlh
@@ -1,0 +1,1 @@
+Hello ${name}!


### PR DESCRIPTION
* to be used by standalone applications, or even by server, if just, for example, email generation is needed and not view resolution using freemarker templates;
* servlet and reactive freemarker configurations can be added later on, when needed; (could be placed under `webMvc` and `webFlux` blocks accordingly)
* add `defaultProperties` to `configurationProperties` function because without some property bound from `app.properties|yml` or environment, "binder.get()" would fail with "java.util.NoSuchElementException: No value bound".