### PR TITLE
feat: Add transactional configuration for R2dbc

### DIFF
--- a/jafu/src/main/java/org/springframework/fu/jafu/r2dbc/R2dbcDsl.java
+++ b/jafu/src/main/java/org/springframework/fu/jafu/r2dbc/R2dbcDsl.java
@@ -24,6 +24,8 @@ public class R2dbcDsl extends AbstractDsl {
 
     private final List<ConnectionFactoryOptionsBuilderCustomizer> optionsCustomizers = new ArrayList<>();
 
+    private boolean transactional = false;
+
     R2dbcDsl(Consumer<R2dbcDsl> dsl) {
         this.dsl = dsl;
     }
@@ -62,10 +64,15 @@ public class R2dbcDsl extends AbstractDsl {
         return this;
     }
 
+    public R2dbcDsl transactional(boolean transactional) {
+        this.transactional = transactional;
+        return this;
+    }
+
     @Override
     public void initialize(GenericApplicationContext context) {
         super.initialize(context);
         this.dsl.accept(this);
-        new R2dbcInitializer(properties, optionsCustomizers).initialize(context);
+        new R2dbcInitializer(properties, optionsCustomizers, transactional).initialize(context);
     }
 }

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/r2dbc/R2dbcDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/r2dbc/R2dbcDsl.kt
@@ -24,13 +24,15 @@ class R2dbcDsl(private val init: R2dbcDsl.() -> Unit) : AbstractDsl(){
 
     var optionsCustomizer: List<ConnectionFactoryOptionsBuilderCustomizer> = emptyList()
 
+    var transactional: Boolean = false
+
     override fun initialize(context: GenericApplicationContext) {
         super.initialize(context)
         init()
 
         val properties = r2dbcProperties()
 
-        R2dbcInitializer(properties, optionsCustomizer).initialize(context)
+        R2dbcInitializer(properties, optionsCustomizer, transactional).initialize(context)
     }
 
     fun r2dbcProperties() : R2dbcProperties =

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/r2dbc/R2dbcDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/r2dbc/R2dbcDslTests.kt
@@ -1,9 +1,12 @@
 package org.springframework.fu.kofu.r2dbc
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.getBean
 import org.springframework.fu.kofu.application
 import org.springframework.r2dbc.core.DatabaseClient
+import org.springframework.transaction.reactive.TransactionalOperator
 import org.testcontainers.containers.GenericContainer
 import reactor.test.StepVerifier
 import java.io.Serializable
@@ -68,6 +71,33 @@ class RedisDslTests {
 		}
 
 		pg.stop()
+	}
+
+	@Test
+	fun `enable trasactional`() {
+		// Check that by default TransactionalOperator is not activated
+		assertThrows<NoSuchBeanDefinitionException> {
+			val app = application {
+				r2dbc {
+					url = "r2dbc:h2:mem:///testdb"
+				}
+			}
+
+			with(app.run()) {
+				getBean<TransactionalOperator>()
+			}
+		}
+
+		val app = application {
+			r2dbc {
+				url = "r2dbc:h2:mem:///testdb"
+				transactional = true
+			}
+		}
+
+		with(app.run()) {
+			getBean<TransactionalOperator>()
+		}
 	}
 }
 

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/r2dbc.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/r2dbc.kt
@@ -2,16 +2,13 @@ package org.springframework.fu.kofu.samples
 
 import org.springframework.fu.kofu.application
 import org.springframework.fu.kofu.r2dbc.r2dbc
-import org.springframework.fu.kofu.r2dbc.r2dbcH2
 import org.springframework.fu.kofu.r2dbc.r2dbcMssql
 import org.springframework.fu.kofu.r2dbc.r2dbcMysql
-import org.springframework.fu.kofu.r2dbc.r2dbcPostgresql
 
 fun r2dbcPostgresql() {
 	application {
-		r2dbcPostgresql {
-			host = "dbserver"
-			port = 1234
+		r2dbc {
+			url = "r2dbc:postgresql://dbserver:1234"
 		}
 	}
 }


### PR DESCRIPTION
## What this PR do 

As suggested in #274, this PR add configuration to add TransactionOperator in context if needed on R2dbc intitialisation

Add transactional configuration for R2dbcInitializer to add TransactionOperator in context if activated
Add transactional flag in Jafu R2dbc configuration
Add trsactional flag in Kofu R2dbc configuration
    
Fix R2dbc postgres sample

### Related issues

Fixes: #274 

