### PR TITLE
add spring security DSL

### DIFF
--- a/autoconfigure-adapter/build.gradle.kts
+++ b/autoconfigure-adapter/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
 	compileOnly("io.r2dbc:r2dbc-h2")
 	compileOnly("io.r2dbc:r2dbc-mssql")
 	compileOnly("com.zaxxer:HikariCP")
+	compileOnly("org.springframework.security:spring-security-web")
+	compileOnly("org.springframework.security:spring-security-config")
 }
 
 repositories {

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/web/servlet/ServletWebServerInitializer.java
@@ -144,7 +144,7 @@ public class ServletWebServerInitializer implements ApplicationContextInitialize
 		context.registerBean(SimpleControllerHandlerAdapter.class, () -> enableWebMvcConfiguration.get().simpleControllerHandlerAdapter());
 		context.registerBean(HandlerExceptionResolver.class, () -> enableWebMvcConfiguration.get().handlerExceptionResolver(context.getBean(ContentNegotiationManager.class)));
 		context.registerBean(ViewResolver.class, () -> enableWebMvcConfiguration.get().mvcViewResolver(context.getBean(ContentNegotiationManager.class)));
-		context.registerBean(HandlerMappingIntrospector.class, () -> enableWebMvcConfiguration.get().mvcHandlerMappingIntrospector(), bd -> bd.setLazyInit(true));
+		context.registerBean("mvcHandlerMappingIntrospector", HandlerMappingIntrospector.class, () -> enableWebMvcConfiguration.get().mvcHandlerMappingIntrospector(), bd -> bd.setLazyInit(true));
 		context.registerBean(WelcomePageHandlerMapping.class, () -> enableWebMvcConfiguration.get().welcomePageHandlerMapping(context, context.getBean(FormattingConversionService.class), context.getBean(ResourceUrlProvider.class)));
 		context.registerBean(DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME, LocaleResolver.class, () -> enableWebMvcConfiguration.get().localeResolver());
 		context.registerBean(DispatcherServlet.THEME_RESOLVER_BEAN_NAME, ThemeResolver.class, () -> enableWebMvcConfiguration.get().themeResolver());

--- a/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityInitializer.java
@@ -25,7 +25,7 @@ public class HttpSecurityInitializer implements ApplicationContextInitializer<Ge
 	private final Consumer<HttpSecurity> httpSecurityDsl;
 	private final AuthenticationManager authenticationManager;
 	private final UserDetailsService userDetailsService;
-	private PasswordEncoder passwordEncoder;
+	private final PasswordEncoder passwordEncoder;
 	private final UserDetailsPasswordService userDetailsPasswordService;
 
 	public HttpSecurityInitializer(Consumer<HttpSecurity> httpSecurityDsl, AuthenticationManager authenticationManager,
@@ -47,16 +47,16 @@ public class HttpSecurityInitializer implements ApplicationContextInitializer<Ge
 		if (authenticationManager != null) {
 			configuration.setAuthenticationManager(authenticationManager);
 		} else {
-			// build authenticationManager otherwise HttpSecurityConfiguration will throw NPE
+			// build authenticationManager, otherwise HttpSecurityConfiguration will throw NPE
 			DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
 			authProvider.setUserDetailsService(userDetailsService);
 			authProvider.setUserDetailsPasswordService(userDetailsPasswordService);
 
-			if (passwordEncoder == null) {
-				passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+			if (passwordEncoder != null) {
+				authProvider.setPasswordEncoder(passwordEncoder);
+			} else {
+				authProvider.setPasswordEncoder(PasswordEncoderFactories.createDelegatingPasswordEncoder());
 			}
-			authProvider.setPasswordEncoder(passwordEncoder);
-			context.registerBean(PasswordEncoder.class, () -> passwordEncoder);
 
 			configuration.setAuthenticationManager(new ProviderManager(authProvider));
 		}
@@ -76,7 +76,6 @@ public class HttpSecurityInitializer implements ApplicationContextInitializer<Ge
 			return httpSecurity;
 		};
 
-		// todo expose configuration '@Bean's
 		context.registerBean(
 				HTTPSECURITY_BEAN_NAME,
 				HttpSecurity.class,

--- a/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityInitializer.java
@@ -1,0 +1,81 @@
+package org.springframework.security.config.annotation.web.configuration;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * {@link ApplicationContextInitializer} adapter for {@link HttpSecurityConfiguration}.
+ */
+public class HttpSecurityInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
+	private static final String BEAN_NAME_PREFIX = "org.springframework.security.config.annotation.web.configuration.HttpSecurityConfiguration.";
+	static final String HTTPSECURITY_BEAN_NAME = BEAN_NAME_PREFIX + "httpSecurity";
+
+	private final Consumer<HttpSecurity> httpSecurityDsl;
+	private final AuthenticationManager authenticationManager;
+	private final UserDetailsService userDetailsService;
+	private final PasswordEncoder passwordEncoder;
+
+	public HttpSecurityInitializer(Consumer<HttpSecurity> httpSecurityDsl, AuthenticationManager authenticationManager,
+								   UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
+		this.httpSecurityDsl = httpSecurityDsl;
+		this.authenticationManager = authenticationManager;
+		this.userDetailsService = userDetailsService;
+		this.passwordEncoder = passwordEncoder;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void initialize(GenericApplicationContext context) {
+		if (passwordEncoder != null) {
+			context.registerBean(PasswordEncoder.class, () -> passwordEncoder);
+		}
+
+		HttpSecurityConfiguration configuration = new HttpSecurityConfiguration();
+		configuration.setApplicationContext(context);
+		if (authenticationManager != null) {
+			configuration.setAuthenticationManager(authenticationManager);
+		}
+
+		Supplier<HttpSecurity> httpSecuritySupplier = () -> {
+			configuration.setObjectPostProcessor(context.getBean(ObjectPostProcessor.class));
+
+			HttpSecurity httpSecurity;
+			try {
+				httpSecurity = configuration.httpSecurity();
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+
+			if (userDetailsService != null) {
+				try {
+					httpSecurity.userDetailsService(userDetailsService);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+
+			this.httpSecurityDsl.accept(httpSecurity);
+
+			return httpSecurity;
+		};
+
+		// todo expose configuration '@Bean's
+		context.registerBean(
+				HTTPSECURITY_BEAN_NAME,
+				HttpSecurity.class,
+				httpSecuritySupplier,
+				bd -> {
+					bd.setScope("prototype");
+					bd.setAutowireCandidate(true);
+				}
+		);
+	}
+}

--- a/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/configuration/ObjectPostProcessorInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/configuration/ObjectPostProcessorInitializer.java
@@ -1,0 +1,18 @@
+package org.springframework.security.config.annotation.web.configuration;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.configuration.ObjectPostProcessorConfiguration;
+
+/**
+ * {@link ApplicationContextInitializer} adapter for {@link ObjectPostProcessorConfiguration}.
+ */
+public class ObjectPostProcessorInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
+
+	@Override
+	public void initialize(GenericApplicationContext context) {
+		ObjectPostProcessorConfiguration configuration = new ObjectPostProcessorConfiguration();
+		context.registerBean(ObjectPostProcessor.class, () -> configuration.objectPostProcessor(context.getBeanFactory()));
+	}
+}

--- a/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/configuration/WebMvcSecurityInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/configuration/WebMvcSecurityInitializer.java
@@ -1,0 +1,63 @@
+package org.springframework.security.config.annotation.web.configuration;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.ResolvableType;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.SecurityConfigurer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
+
+import javax.servlet.Filter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * {@link ApplicationContextInitializer} adapter for {@link WebSecurityConfiguration}.
+ */
+public class WebMvcSecurityInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void initialize(GenericApplicationContext context) {
+		Supplier<WebSecurityConfiguration> configurationSupplier = () -> {
+			WebSecurityConfiguration configuration = new WebSecurityConfiguration();
+			HttpSecurity security = context.getBean(HttpSecurityInitializer.HTTPSECURITY_BEAN_NAME, HttpSecurity.class);
+			try {
+				configuration.setFilterChains(Collections.singletonList(security.build()));
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+
+			List<SecurityConfigurer<Filter, WebSecurity>> webSecurityConfigurers = new ArrayList<>();
+			String[] webSecurityConfigurerBeanNames = context.getBeanNamesForType(
+					ResolvableType.forClassWithGenerics(SecurityConfigurer.class, Filter.class, WebSecurity.class));
+			for (String webSecurityConfigurerBeanName : webSecurityConfigurerBeanNames) {
+				webSecurityConfigurers.add((SecurityConfigurer<Filter, WebSecurity>) context.getBean(webSecurityConfigurerBeanName));
+			}
+			try {
+				configuration.setFilterChainProxySecurityConfigurer(context.getBean(ObjectPostProcessor.class), webSecurityConfigurers);
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+
+			return configuration;
+		};
+
+		context.registerBean(
+				AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME,
+				Filter.class,
+				() -> {
+					try {
+						return configurationSupplier.get().springSecurityFilterChain();
+					} catch (Exception e) {
+						e.printStackTrace();
+					}
+					return null;
+				}
+		);
+	}
+}

--- a/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/configuration/WebMvcSecurityInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/configuration/WebMvcSecurityInitializer.java
@@ -2,62 +2,23 @@ package org.springframework.security.config.annotation.web.configuration;
 
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.support.GenericApplicationContext;
-import org.springframework.core.ResolvableType;
-import org.springframework.security.config.annotation.ObjectPostProcessor;
-import org.springframework.security.config.annotation.SecurityConfigurer;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
-import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
+import org.springframework.web.servlet.support.RequestDataValueProcessor;
 
-import javax.servlet.Filter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.function.Supplier;
 
 /**
- * {@link ApplicationContextInitializer} adapter for {@link WebSecurityConfiguration}.
+ * {@link ApplicationContextInitializer} adapter for {@link WebMvcSecurityConfiguration}.
  */
 public class WebMvcSecurityInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public void initialize(GenericApplicationContext context) {
-		Supplier<WebSecurityConfiguration> configurationSupplier = () -> {
-			WebSecurityConfiguration configuration = new WebSecurityConfiguration();
-			HttpSecurity security = context.getBean(HttpSecurityInitializer.HTTPSECURITY_BEAN_NAME, HttpSecurity.class);
-			try {
-				configuration.setFilterChains(Collections.singletonList(security.build()));
-			} catch (Exception e) {
-				throw new IllegalStateException(e);
-			}
-
-			List<SecurityConfigurer<Filter, WebSecurity>> webSecurityConfigurers = new ArrayList<>();
-			String[] webSecurityConfigurerBeanNames = context.getBeanNamesForType(
-					ResolvableType.forClassWithGenerics(SecurityConfigurer.class, Filter.class, WebSecurity.class));
-			for (String webSecurityConfigurerBeanName : webSecurityConfigurerBeanNames) {
-				webSecurityConfigurers.add((SecurityConfigurer<Filter, WebSecurity>) context.getBean(webSecurityConfigurerBeanName));
-			}
-			try {
-				configuration.setFilterChainProxySecurityConfigurer(context.getBean(ObjectPostProcessor.class), webSecurityConfigurers);
-			} catch (Exception e) {
-				throw new IllegalStateException(e);
-			}
-
+		final WebMvcSecurityConfiguration configuration = new WebMvcSecurityConfiguration();
+		Supplier<WebMvcSecurityConfiguration> configurationSupplier = () -> {
+			configuration.setApplicationContext(context);
 			return configuration;
 		};
 
-		context.registerBean(
-				AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME,
-				Filter.class,
-				() -> {
-					try {
-						return configurationSupplier.get().springSecurityFilterChain();
-					} catch (Exception e) {
-						e.printStackTrace();
-					}
-					return null;
-				}
-		);
+		context.registerBean(RequestDataValueProcessor.class, () -> configurationSupplier.get().requestDataValueProcessor());
 	}
 }

--- a/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityInitializer.java
@@ -1,0 +1,84 @@
+package org.springframework.security.config.annotation.web.configuration;
+
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.ResolvableType;
+import org.springframework.security.access.expression.SecurityExpressionHandler;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.SecurityConfigurer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.web.FilterInvocation;
+import org.springframework.security.web.access.WebInvocationPrivilegeEvaluator;
+import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
+
+import javax.servlet.Filter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * {@link ApplicationContextInitializer} adapter for {@link WebSecurityConfiguration}.
+ */
+public class WebSecurityInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void initialize(GenericApplicationContext context) {
+
+		Supplier<WebSecurityConfiguration> configurationSupplier = new Supplier<WebSecurityConfiguration>() {
+			private WebSecurityConfiguration configuration;
+
+			@Override
+			public WebSecurityConfiguration get() {
+				if (configuration == null) {
+					configuration = new WebSecurityConfiguration();
+					HttpSecurity security = context.getBean(HttpSecurityInitializer.HTTPSECURITY_BEAN_NAME, HttpSecurity.class);
+					try {
+						configuration.setFilterChains(Collections.singletonList(security.build()));
+					} catch (Exception e) {
+						throw new IllegalStateException(e);
+					}
+
+					List<SecurityConfigurer<Filter, WebSecurity>> webSecurityConfigurers = new ArrayList<>();
+					String[] webSecurityConfigurerBeanNames = context.getBeanNamesForType(
+							ResolvableType.forClassWithGenerics(SecurityConfigurer.class, Filter.class, WebSecurity.class));
+					for (String webSecurityConfigurerBeanName : webSecurityConfigurerBeanNames) {
+						webSecurityConfigurers.add((SecurityConfigurer<Filter, WebSecurity>) context.getBean(webSecurityConfigurerBeanName));
+					}
+					try {
+						configuration.setFilterChainProxySecurityConfigurer(context.getBean(ObjectPostProcessor.class), webSecurityConfigurers);
+					} catch (Exception e) {
+						throw new IllegalStateException(e);
+					}
+				}
+				return configuration;
+			}
+		};
+
+		context.registerBean(
+				SecurityExpressionHandler.class,
+				() -> configurationSupplier.get().webSecurityExpressionHandler(),
+				bd -> bd.setDependsOn(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME)
+		);
+		context.registerBean(
+				AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME,
+				Filter.class,
+				() -> {
+					try {
+						return configurationSupplier.get().springSecurityFilterChain();
+					} catch (Exception e) {
+						e.printStackTrace();
+					}
+					return null;
+				}
+		);
+		context.registerBean(
+				WebInvocationPrivilegeEvaluator.class,
+				() -> configurationSupplier.get().privilegeEvaluator(),
+				bd -> bd.setDependsOn(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME)
+		);
+	}
+}

--- a/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/reactive/ServerHttpSecurityInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/reactive/ServerHttpSecurityInitializer.java
@@ -1,0 +1,85 @@
+package org.springframework.security.config.annotation.web.reactive;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.ReactiveAdapterRegistry;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsPasswordService;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.reactive.result.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.security.web.reactive.result.method.annotation.CurrentSecurityContextArgumentResolver;
+
+import java.util.function.Supplier;
+
+/**
+ * {@link ApplicationContextInitializer} adapter for {@link org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration}.
+ */
+public class ServerHttpSecurityInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
+	private static final String BEAN_NAME_PREFIX = "org.springframework.security.config.annotation.web.reactive.HttpSecurityConfiguration.";
+	private static final String HTTPSECURITY_BEAN_NAME = BEAN_NAME_PREFIX + "httpSecurity";
+
+	private final ReactiveAuthenticationManager authenticationManager;
+	private final ReactiveUserDetailsService reactiveUserDetailsService;
+	private final PasswordEncoder passwordEncoder;
+	private final ReactiveUserDetailsPasswordService userDetailsPasswordService;
+	private ServerHttpSecurity httpSecurity;
+
+	/**
+	 * @param authenticationManager      {@link ServerHttpSecurityConfiguration}
+	 * @param reactiveUserDetailsService {@link ServerHttpSecurityConfiguration}
+	 * @param passwordEncoder            {@link ServerHttpSecurityConfiguration}
+	 * @param userDetailsPasswordService {@link ServerHttpSecurityConfiguration}
+	 */
+	public ServerHttpSecurityInitializer(
+			ReactiveAuthenticationManager authenticationManager,
+			ReactiveUserDetailsService reactiveUserDetailsService,
+			PasswordEncoder passwordEncoder,
+			ReactiveUserDetailsPasswordService userDetailsPasswordService) {
+		this.authenticationManager = authenticationManager;
+		this.reactiveUserDetailsService = reactiveUserDetailsService;
+		this.passwordEncoder = passwordEncoder;
+		this.userDetailsPasswordService = userDetailsPasswordService;
+	}
+
+	@Override
+	public void initialize(GenericApplicationContext context) {
+		final ServerHttpSecurityConfiguration configuration = new ServerHttpSecurityConfiguration();
+		if (authenticationManager != null) {
+			configuration.setAuthenticationManager(authenticationManager);
+		}
+		if (reactiveUserDetailsService != null) {
+			configuration.setReactiveUserDetailsService(reactiveUserDetailsService);
+		}
+		if (passwordEncoder != null) {
+			configuration.setPasswordEncoder(passwordEncoder);
+		}
+		if (userDetailsPasswordService != null) {
+			configuration.setUserDetailsPasswordService(userDetailsPasswordService);
+		}
+
+		this.httpSecurity = configuration.httpSecurity();
+
+		Supplier<ServerHttpSecurityConfiguration> configurationSupplier = () -> {
+			configuration.setAdapterRegistry(context.getBean(ReactiveAdapterRegistry.class));
+			return configuration;
+		};
+
+		context.registerBean(AuthenticationPrincipalArgumentResolver.class, () -> configurationSupplier.get().authenticationPrincipalArgumentResolver());
+		context.registerBean(CurrentSecurityContextArgumentResolver.class, () -> configurationSupplier.get().reactiveCurrentSecurityContextArgumentResolver());
+		context.registerBean(
+				HTTPSECURITY_BEAN_NAME,
+				ServerHttpSecurity.class,
+				() -> this.httpSecurity,
+				bd -> {
+					bd.setScope("prototype");
+					bd.setAutowireCandidate(true);
+				}
+		);
+	}
+
+	public ServerHttpSecurity getHttpSecurity() {
+		return httpSecurity;
+	}
+}

--- a/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/reactive/WebFluxSecurityInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/security/config/annotation/web/reactive/WebFluxSecurityInitializer.java
@@ -1,0 +1,45 @@
+package org.springframework.security.config.annotation.web.reactive;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.security.web.reactive.result.view.CsrfRequestDataValueProcessor;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.WebFilterChainProxy;
+import org.springframework.web.reactive.result.view.AbstractView;
+
+import java.util.Collections;
+
+/**
+ * {@link ApplicationContextInitializer} adapter for {@link WebFluxSecurityConfiguration}.
+ */
+public class WebFluxSecurityInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
+	private static final String BEAN_NAME_PREFIX = "org.springframework.security.config.annotation.web.reactive.WebFluxSecurityConfiguration.";
+	private static final String SPRING_SECURITY_WEBFILTERCHAINFILTER_BEAN_NAME = BEAN_NAME_PREFIX + "WebFilterChainFilter";
+
+	private final SecurityWebFilterChain webFilterChain;
+
+	public WebFluxSecurityInitializer(SecurityWebFilterChain webFilterChain) {
+		this.webFilterChain = webFilterChain;
+	}
+
+	@Override
+	public void initialize(GenericApplicationContext context) {
+		WebFluxSecurityConfiguration configuration = new WebFluxSecurityConfiguration();
+		configuration.context = context;
+
+		if (webFilterChain != null) {
+			configuration.setSecurityWebFilterChains(Collections.singletonList(webFilterChain));
+		}
+
+		context.registerBean(
+				SPRING_SECURITY_WEBFILTERCHAINFILTER_BEAN_NAME,
+				WebFilterChainProxy.class,
+				configuration::springSecurityWebFilterChainFilter
+		);
+		context.registerBean(
+				AbstractView.REQUEST_DATA_VALUE_PROCESSOR_BEAN_NAME,
+				CsrfRequestDataValueProcessor.class,
+				configuration::requestDataValueProcessor
+		);
+	}
+}

--- a/kofu/build.gradle.kts
+++ b/kofu/build.gradle.kts
@@ -17,6 +17,8 @@ dependencies {
 
 	compileOnly("org.springframework:spring-webmvc")
 	compileOnly("org.springframework:spring-webflux")
+	compileOnly("org.springframework.security:spring-security-web")
+	compileOnly("org.springframework.security:spring-security-config")
 	compileOnly("de.flapdoodle.embed:de.flapdoodle.embed.mongo")
 	compileOnly("org.springframework.data:spring-data-mongodb")
 	compileOnly("org.springframework.data:spring-data-r2dbc")
@@ -44,6 +46,7 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
 	testImplementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
 	testImplementation("org.springframework.boot:spring-boot-starter-jdbc")
+	testImplementation("org.springframework.boot:spring-boot-starter-security")
 	testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	testRuntimeOnly("de.flapdoodle.embed:de.flapdoodle.embed.mongo")
 	testImplementation("io.mockk:mockk:1.9")
@@ -75,6 +78,9 @@ tasks.withType<DokkaTask> {
 		}
 		externalDocumentationLink {
 			url = URL("https://docs.spring.io/spring-framework/docs/current/kdoc-api/spring-framework/")
+		}
+		externalDocumentationLink {
+			url = URL("https://docs.spring.io/spring-security/site/docs/current/api/")
 		}
 		externalDocumentationLink {
 			url = URL("https://fasterxml.github.io/jackson-core/javadoc/2.9/")

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/webflux/SecurityDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/webflux/SecurityDsl.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.fu.kofu.webflux
+
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.fu.kofu.AbstractDsl
+import org.springframework.security.authentication.ReactiveAuthenticationManager
+import org.springframework.security.config.annotation.web.reactive.ServerHttpSecurityInitializer
+import org.springframework.security.config.annotation.web.reactive.WebFluxSecurityInitializer
+import org.springframework.security.core.userdetails.ReactiveUserDetailsPasswordService
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.config.web.server.ServerHttpSecurityDsl
+import org.springframework.security.config.web.server.invoke
+
+/**
+ * Kofu DSL for spring-security.
+ *
+ * Configure spring-security.
+ *
+ * Required dependencies can be retrieve using `org.springframework.boot:spring-boot-starter-security`.
+ *
+ * @author Jonas Bark, Ivan Skachkov
+ */
+class SecurityDsl(private val init: SecurityDsl.() -> Unit) : AbstractDsl() {
+
+	var authenticationManager: ReactiveAuthenticationManager? = null
+
+	var reactiveUserDetailsService: ReactiveUserDetailsService? = null
+
+	var passwordEncoder: PasswordEncoder? = null
+
+	var userDetailsPasswordService: ReactiveUserDetailsPasswordService? = null
+
+	var http: ServerHttpSecurityDsl.() -> Unit = {}
+
+	override fun initialize(context: GenericApplicationContext) {
+		super.initialize(context)
+		init()
+
+		val securityInitializer = ServerHttpSecurityInitializer(
+				authenticationManager,
+				reactiveUserDetailsService,
+				passwordEncoder,
+				userDetailsPasswordService
+		)
+		securityInitializer.initialize(context)
+
+		val chain = securityInitializer.httpSecurity.invoke(http)
+
+		WebFluxSecurityInitializer(chain).initialize(context)
+	}
+}
+
+/**
+ * Configure spring-security.
+ *
+ * Requires `org.springframework.boot:spring-boot-starter-security` dependency.
+ *
+ * @sample org.springframework.fu.kofu.samples.webFluxSecurity
+ * @author Jonas Bark
+ */
+fun WebFluxServerDsl.security(dsl: SecurityDsl.() -> Unit = {}) {
+	SecurityDsl(dsl).initialize(context)
+}

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/webflux/SecurityDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/webflux/SecurityDsl.kt
@@ -40,7 +40,7 @@ class SecurityDsl(private val init: SecurityDsl.() -> Unit) : AbstractDsl() {
 
 	var authenticationManager: ReactiveAuthenticationManager? = null
 
-	var reactiveUserDetailsService: ReactiveUserDetailsService? = null
+	var userDetailsService: ReactiveUserDetailsService? = null
 
 	var passwordEncoder: PasswordEncoder? = null
 
@@ -58,7 +58,7 @@ class SecurityDsl(private val init: SecurityDsl.() -> Unit) : AbstractDsl() {
 
 		val securityInitializer = ServerHttpSecurityInitializer(
 				authenticationManager,
-				reactiveUserDetailsService,
+				userDetailsService,
 				passwordEncoder,
 				userDetailsPasswordService
 		)

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/webflux/SecurityDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/webflux/SecurityDsl.kt
@@ -34,7 +34,7 @@ import org.springframework.security.config.web.server.invoke
  *
  * Required dependencies can be retrieve using `org.springframework.boot:spring-boot-starter-security`.
  *
- * @author Jonas Bark, Ivan Skachkov
+ * @author Jonas Bark, Ivan Skachkov, Fred Montariol
  */
 class SecurityDsl(private val init: SecurityDsl.() -> Unit) : AbstractDsl() {
 
@@ -46,7 +46,11 @@ class SecurityDsl(private val init: SecurityDsl.() -> Unit) : AbstractDsl() {
 
 	var userDetailsPasswordService: ReactiveUserDetailsPasswordService? = null
 
-	var http: ServerHttpSecurityDsl.() -> Unit = {}
+	private var httpConfiguration: ServerHttpSecurityDsl.() -> Unit = {}
+
+	fun http(httpConfiguration: ServerHttpSecurityDsl.() -> Unit = {}) {
+		this.httpConfiguration = httpConfiguration
+	}
 
 	override fun initialize(context: GenericApplicationContext) {
 		super.initialize(context)
@@ -60,7 +64,7 @@ class SecurityDsl(private val init: SecurityDsl.() -> Unit) : AbstractDsl() {
 		)
 		securityInitializer.initialize(context)
 
-		val chain = securityInitializer.httpSecurity.invoke(http)
+		val chain = securityInitializer.httpSecurity.invoke(httpConfiguration)
 
 		WebFluxSecurityInitializer(chain).initialize(context)
 	}

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/webmvc/SecurityDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/webmvc/SecurityDsl.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.fu.kofu.webmvc
+
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.fu.kofu.AbstractDsl
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.config.annotation.web.configuration.HttpSecurityInitializer
+import org.springframework.security.config.annotation.web.configuration.ObjectPostProcessorInitializer
+import org.springframework.security.config.annotation.web.configuration.WebMvcSecurityInitializer
+import org.springframework.security.config.web.servlet.HttpSecurityDsl
+import org.springframework.security.config.web.servlet.invoke
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.crypto.password.PasswordEncoder
+import java.util.function.Consumer
+
+/**
+ * Kofu DSL for spring-security.
+ *
+ * Configure spring-security.
+ *
+ * Required dependencies can be retrieve using `org.springframework.boot:spring-boot-starter-security`.
+ *
+ * @author Fred Montariol
+ */
+class SecurityDsl(private val init: SecurityDsl.() -> Unit) : AbstractDsl() {
+
+	var authenticationManager: AuthenticationManager? = null
+
+	var userDetailsService: UserDetailsService? = null
+
+	var passwordEncoder: PasswordEncoder? = null
+
+	var http: HttpSecurityDsl.() -> Unit = {}
+
+	override fun initialize(context: GenericApplicationContext) {
+		super.initialize(context)
+		init()
+
+		ObjectPostProcessorInitializer().initialize(context)
+
+		val securityInitializer = HttpSecurityInitializer(Consumer { it.invoke(http) },
+				authenticationManager, userDetailsService, passwordEncoder)
+
+		securityInitializer.initialize(context)
+
+		WebMvcSecurityInitializer().initialize(context)
+	}
+}
+
+/**
+ * Configure spring-security.
+ *
+ * Requires `org.springframework.boot:spring-boot-starter-security` dependency.
+ *
+ * @sample org.springframework.fu.kofu.samples.webMvcSecurity
+ * @author Fred Montariol
+ */
+fun WebMvcServerDsl.security(dsl: SecurityDsl.() -> Unit = {}) {
+	SecurityDsl(dsl).initialize(context)
+}

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/webmvc/SecurityDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/webmvc/SecurityDsl.kt
@@ -24,6 +24,7 @@ import org.springframework.security.config.annotation.web.configuration.ObjectPo
 import org.springframework.security.config.annotation.web.configuration.WebMvcSecurityInitializer
 import org.springframework.security.config.web.servlet.HttpSecurityDsl
 import org.springframework.security.config.web.servlet.invoke
+import org.springframework.security.core.userdetails.UserDetailsPasswordService
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.util.function.Consumer
@@ -45,6 +46,8 @@ class SecurityDsl(private val init: SecurityDsl.() -> Unit) : AbstractDsl() {
 
 	var passwordEncoder: PasswordEncoder? = null
 
+	var userDetailsPasswordService: UserDetailsPasswordService? = null
+
 	private var httpConfiguration: HttpSecurityDsl.() -> Unit = {}
 
 	fun http(httpConfiguration: HttpSecurityDsl.() -> Unit = {}) {
@@ -58,7 +61,7 @@ class SecurityDsl(private val init: SecurityDsl.() -> Unit) : AbstractDsl() {
 		ObjectPostProcessorInitializer().initialize(context)
 
 		val securityInitializer = HttpSecurityInitializer(Consumer { it.invoke(httpConfiguration) },
-				authenticationManager, userDetailsService, passwordEncoder)
+                authenticationManager, userDetailsService, passwordEncoder, userDetailsPasswordService)
 
 		securityInitializer.initialize(context)
 

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/webmvc/SecurityDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/webmvc/SecurityDsl.kt
@@ -22,6 +22,7 @@ import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.config.annotation.web.configuration.HttpSecurityInitializer
 import org.springframework.security.config.annotation.web.configuration.ObjectPostProcessorInitializer
 import org.springframework.security.config.annotation.web.configuration.WebMvcSecurityInitializer
+import org.springframework.security.config.annotation.web.configuration.WebSecurityInitializer
 import org.springframework.security.config.web.servlet.HttpSecurityDsl
 import org.springframework.security.config.web.servlet.invoke
 import org.springframework.security.core.userdetails.UserDetailsPasswordService
@@ -65,6 +66,7 @@ class SecurityDsl(private val init: SecurityDsl.() -> Unit) : AbstractDsl() {
 
 		securityInitializer.initialize(context)
 
+		WebSecurityInitializer().initialize(context)
 		WebMvcSecurityInitializer().initialize(context)
 	}
 }

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/webmvc/SecurityDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/webmvc/SecurityDsl.kt
@@ -45,7 +45,11 @@ class SecurityDsl(private val init: SecurityDsl.() -> Unit) : AbstractDsl() {
 
 	var passwordEncoder: PasswordEncoder? = null
 
-	var http: HttpSecurityDsl.() -> Unit = {}
+	private var httpConfiguration: HttpSecurityDsl.() -> Unit = {}
+
+	fun http(httpConfiguration: HttpSecurityDsl.() -> Unit = {}) {
+		this.httpConfiguration = httpConfiguration
+	}
 
 	override fun initialize(context: GenericApplicationContext) {
 		super.initialize(context)
@@ -53,7 +57,7 @@ class SecurityDsl(private val init: SecurityDsl.() -> Unit) : AbstractDsl() {
 
 		ObjectPostProcessorInitializer().initialize(context)
 
-		val securityInitializer = HttpSecurityInitializer(Consumer { it.invoke(http) },
+		val securityInitializer = HttpSecurityInitializer(Consumer { it.invoke(httpConfiguration) },
 				authenticationManager, userDetailsService, passwordEncoder)
 
 		securityInitializer.initialize(context)

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/webfluxsecurity.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/webfluxsecurity.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.fu.kofu.samples
+
+import org.springframework.fu.kofu.reactiveWebApplication
+import org.springframework.fu.kofu.webflux.security
+import org.springframework.fu.kofu.webflux.webFlux
+
+fun webFluxSecurity() {
+	reactiveWebApplication {
+		webFlux {
+			security {
+				// authenticationManager = repoAuthenticationManager
+				http = {
+					anonymous { }
+					authorizeExchange {
+						authorize("/view", hasRole("USER"))
+						authorize("/public-view", permitAll)
+					}
+					headers {}
+					logout {}
+				}
+			}
+		}
+	}
+}

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/webfluxsecurity.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/webfluxsecurity.kt
@@ -19,12 +19,14 @@ package org.springframework.fu.kofu.samples
 import org.springframework.fu.kofu.reactiveWebApplication
 import org.springframework.fu.kofu.webflux.security
 import org.springframework.fu.kofu.webflux.webFlux
+import org.springframework.security.core.userdetails.MapReactiveUserDetailsService
+import org.springframework.security.core.userdetails.User
 
 fun webFluxSecurity() {
 	reactiveWebApplication {
 		webFlux {
 			security {
-				// authenticationManager = repoAuthenticationManager
+				userDetailsService = userDetailsService()
 				http {
 					anonymous { }
 					authorizeExchange {
@@ -38,3 +40,13 @@ fun webFluxSecurity() {
 		}
 	}
 }
+
+private fun userDetailsService() =
+		MapReactiveUserDetailsService(
+				@Suppress("DEPRECATION")
+				User.withDefaultPasswordEncoder()
+						.username("username")
+						.password("password")
+						.roles("USER")
+						.build()
+		)

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/webfluxsecurity.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/webfluxsecurity.kt
@@ -25,7 +25,7 @@ fun webFluxSecurity() {
 		webFlux {
 			security {
 				// authenticationManager = repoAuthenticationManager
-				http = {
+				http {
 					anonymous { }
 					authorizeExchange {
 						authorize("/view", hasRole("USER"))

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/webmvcsecurity.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/webmvcsecurity.kt
@@ -1,0 +1,24 @@
+package org.springframework.fu.kofu.samples
+
+import org.springframework.fu.kofu.webApplication
+import org.springframework.fu.kofu.webmvc.security
+import org.springframework.fu.kofu.webmvc.webMvc
+
+fun webMvcSecurity() {
+	webApplication {
+		webMvc {
+			security {
+				// authenticationManager = repoAuthenticationManager
+				http = {
+					anonymous { }
+					authorizeRequests {
+						authorize("/view", hasRole("USER"))
+						authorize("/public-view", permitAll)
+					}
+					headers {}
+					logout {}
+				}
+			}
+		}
+	}
+}

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/webmvcsecurity.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/samples/webmvcsecurity.kt
@@ -9,7 +9,7 @@ fun webMvcSecurity() {
 		webMvc {
 			security {
 				// authenticationManager = repoAuthenticationManager
-				http = {
+				http {
 					anonymous { }
 					authorizeRequests {
 						authorize("/view", hasRole("USER"))

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/webflux/SecurityDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/webflux/SecurityDslTests.kt
@@ -52,7 +52,7 @@ class SecurityDslTests {
 				security {
 					authenticationManager = repoAuthenticationManager
 
-					http = {
+					http {
 						authorizeExchange {
 							authorize("/public-view", permitAll)
 							authorize("/view", hasRole("USER"))

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/webflux/SecurityDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/webflux/SecurityDslTests.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.fu.kofu.webflux
+
+import org.junit.jupiter.api.Test
+import org.springframework.fu.kofu.localServerPort
+import org.springframework.fu.kofu.reactiveWebApplication
+import org.springframework.security.authentication.UserDetailsRepositoryReactiveAuthenticationManager
+import org.springframework.security.core.userdetails.MapReactiveUserDetailsService
+import org.springframework.security.core.userdetails.User
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.nio.charset.Charset
+import java.time.Duration
+import java.util.*
+
+
+/**
+ * @author Jonas Bark, Ivan Skachkov, Fred Montariol
+ */
+class SecurityDslTests {
+
+	@Test
+	fun `Check spring-security configuration DSL`() {
+
+		val username = "user"
+		val password = "password"
+		val repoAuthenticationManager =
+				UserDetailsRepositoryReactiveAuthenticationManager(userDetailsService(username, password))
+
+		val app = reactiveWebApplication {
+			webFlux {
+				port = 0
+				router {
+					GET("/public-view") { ok().build() }
+					GET("/view") { ok().build() }
+				}
+
+				security {
+					authenticationManager = repoAuthenticationManager
+
+					http = {
+						authorizeExchange {
+							authorize("/public-view", permitAll)
+							authorize("/view", hasRole("USER"))
+						}
+						httpBasic {}
+					}
+				}
+			}
+		}
+		with(app.run()) {
+			val client = WebTestClient.bindToServer().baseUrl("http://127.0.0.1:$localServerPort")
+					.responseTimeout(Duration.ofMinutes(10)) // useful for debug
+					.build()
+
+			client.get().uri("/public-view").exchange()
+					.expectStatus().is2xxSuccessful
+
+			client.get().uri("/view").exchange()
+					.expectStatus().isUnauthorized
+
+			val basicAuth =
+					Base64.getEncoder().encode("$username:$password".toByteArray()).toString(Charset.defaultCharset())
+			client.get().uri("/view").header("Authorization", "Basic $basicAuth").exchange()
+					.expectStatus().is2xxSuccessful
+
+			val basicAuthWrong =
+					Base64.getEncoder().encode("user:pass".toByteArray()).toString(Charset.defaultCharset())
+			client.get().uri("/view").header("Authorization", "Basic $basicAuthWrong").exchange()
+					.expectStatus().isUnauthorized
+
+			close()
+		}
+	}
+
+	private fun userDetailsService(username: String, password: String) =
+			MapReactiveUserDetailsService(
+					@Suppress("DEPRECATION")
+					User.withDefaultPasswordEncoder()
+							.username(username)
+							.password(password)
+							.roles("USER")
+							.build()
+			)
+}

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/webmvc/SecurityDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/webmvc/SecurityDslTests.kt
@@ -17,10 +17,12 @@
 package org.springframework.fu.kofu.webmvc
 
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.getBean
 import org.springframework.fu.kofu.localServerPort
 import org.springframework.fu.kofu.webApplication
 import org.springframework.security.authentication.ProviderManager
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.provisioning.InMemoryUserDetailsManager
 import org.springframework.test.web.reactive.server.WebTestClient
@@ -62,6 +64,9 @@ class SecurityDslTests {
 			}
 		}
 		app.run().use { context ->
+			// verify that beans are present in context
+			context.getBean<HttpSecurity>()
+
 			val client = WebTestClient.bindToServer().baseUrl("http://127.0.0.1:${context.localServerPort}")
 					.responseTimeout(Duration.ofMinutes(10)) // useful for debug
 					.build()
@@ -110,11 +115,15 @@ class SecurityDslTests {
 							authorize("/view", hasRole("USER"))
 						}
 						httpBasic {}
+						csrf {}
 					}
 				}
 			}
 		}
 		app.run().use { context ->
+			// verify that beans are present in context
+			context.getBean<HttpSecurity>()
+
 			val client = WebTestClient.bindToServer().baseUrl("http://127.0.0.1:${context.localServerPort}")
 					.responseTimeout(Duration.ofMinutes(10)) // useful for debug
 					.build()

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/webmvc/SecurityDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/webmvc/SecurityDslTests.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.fu.kofu.webmvc
+
+import org.junit.jupiter.api.Test
+import org.springframework.fu.kofu.localServerPort
+import org.springframework.fu.kofu.webApplication
+import org.springframework.security.authentication.ProviderManager
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.provisioning.InMemoryUserDetailsManager
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.nio.charset.Charset
+import java.time.Duration
+import java.util.*
+
+
+/**
+ * @author Fred Montariol
+ */
+class SecurityDslTests {
+
+	@Test
+	fun `Check spring-security configuration DSL`() {
+
+		val username = "user"
+		val password = "password"
+		val authProvider = DaoAuthenticationProvider()
+		authProvider.setUserDetailsService(userDetailsService(username, password))
+		val repoAuthenticationManager = ProviderManager(authProvider)
+
+		val app = webApplication {
+			webMvc {
+				port = 0
+				router {
+					GET("/public-view") { ok().build() }
+					GET("/view") { ok().build() }
+				}
+
+				security {
+					authenticationManager = repoAuthenticationManager
+
+					http = {
+						authorizeRequests {
+							authorize("/public-view", permitAll)
+							authorize("/view", hasRole("USER"))
+						}
+						httpBasic {}
+					}
+				}
+			}
+		}
+		with(app.run()) {
+			val client = WebTestClient.bindToServer().baseUrl("http://127.0.0.1:$localServerPort")
+					.responseTimeout(Duration.ofMinutes(10)) // useful for debug
+					.build()
+
+			client.get().uri("/public-view").exchange()
+					.expectStatus().is2xxSuccessful
+
+			client.get().uri("/view").exchange()
+					.expectStatus().isUnauthorized
+
+			val basicAuth =
+					Base64.getEncoder().encode("$username:$password".toByteArray()).toString(Charset.defaultCharset())
+			client.get().uri("/view").header("Authorization", "Basic $basicAuth").exchange()
+					.expectStatus().is2xxSuccessful
+
+			val basicAuthWrong =
+					Base64.getEncoder().encode("user:pass".toByteArray()).toString(Charset.defaultCharset())
+			client.get().uri("/view").header("Authorization", "Basic $basicAuthWrong").exchange()
+					.expectStatus().isUnauthorized
+
+			close()
+		}
+	}
+
+	private fun userDetailsService(username: String, password: String) =
+			InMemoryUserDetailsManager(
+					@Suppress("DEPRECATION")
+					User.withDefaultPasswordEncoder()
+							.username(username)
+							.password(password)
+							.roles("USER")
+							.build()
+			)
+}

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/webmvc/SecurityDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/webmvc/SecurityDslTests.kt
@@ -54,7 +54,7 @@ class SecurityDslTests {
 				security {
 					authenticationManager = repoAuthenticationManager
 
-					http = {
+					http {
 						authorizeRequests {
 							authorize("/public-view", permitAll)
 							authorize("/view", hasRole("USER"))

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/webmvc/SecurityDslTests.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/webmvc/SecurityDslTests.kt
@@ -35,7 +35,57 @@ import java.util.*
 class SecurityDslTests {
 
 	@Test
-	fun `Check spring-security configuration DSL`() {
+	fun `Check spring-security configuration DSL with provided userDetailsService`() {
+
+		val username = "user"
+		val password = "password"
+
+		val app = webApplication {
+			webMvc {
+				port = 0
+				router {
+					GET("/public-view") { ok().build() }
+					GET("/view") { ok().build() }
+				}
+
+				security {
+					userDetailsService = userDetailsService(username, password)
+
+					http {
+						authorizeRequests {
+							authorize("/public-view", permitAll)
+							authorize("/view", hasRole("USER"))
+						}
+						httpBasic {}
+					}
+				}
+			}
+		}
+		app.run().use { context ->
+			val client = WebTestClient.bindToServer().baseUrl("http://127.0.0.1:${context.localServerPort}")
+					.responseTimeout(Duration.ofMinutes(10)) // useful for debug
+					.build()
+
+			client.get().uri("/public-view").exchange()
+					.expectStatus().is2xxSuccessful
+
+			client.get().uri("/view").exchange()
+					.expectStatus().isUnauthorized
+
+			val basicAuth =
+					Base64.getEncoder().encode("$username:$password".toByteArray()).toString(Charset.defaultCharset())
+			client.get().uri("/view").header("Authorization", "Basic $basicAuth").exchange()
+					.expectStatus().is2xxSuccessful
+
+			val basicAuthWrong =
+					Base64.getEncoder().encode("user:pass".toByteArray()).toString(Charset.defaultCharset())
+			client.get().uri("/view").header("Authorization", "Basic $basicAuthWrong").exchange()
+					.expectStatus().isUnauthorized
+		}
+	}
+
+	@Test
+	fun `Check spring-security configuration DSL with provided authenticationManager`() {
 
 		val username = "user"
 		val password = "password"
@@ -64,8 +114,8 @@ class SecurityDslTests {
 				}
 			}
 		}
-		with(app.run()) {
-			val client = WebTestClient.bindToServer().baseUrl("http://127.0.0.1:$localServerPort")
+		app.run().use { context ->
+			val client = WebTestClient.bindToServer().baseUrl("http://127.0.0.1:${context.localServerPort}")
 					.responseTimeout(Duration.ofMinutes(10)) // useful for debug
 					.build()
 
@@ -84,8 +134,6 @@ class SecurityDslTests {
 					Base64.getEncoder().encode("user:pass".toByteArray()).toString(Charset.defaultCharset())
 			client.get().uri("/view").header("Authorization", "Basic $basicAuthWrong").exchange()
 					.expectStatus().isUnauthorized
-
-			close()
 		}
 	}
 


### PR DESCRIPTION
- Complete work of @jonasbark and @skivol, now using DSLs from spring-security 5.4
- Add spring-security support for Spring MVC

fixes #16 

For webFlux
```kotlin
webFlux {
    port = 0
    router {
        GET("/public-view") { ok().build() }
        GET("/view") { ok().build() }
    }

    security {
        authenticationManager = repoAuthenticationManager

        http {
            authorizeExchange {
                authorize("/public-view", permitAll)
                authorize("/view", hasRole("USER"))
            }
            httpBasic {}
        }
    }
}
```

For webMvc
```kotlin
webMvc {
    port = 0
    router {
        GET("/public-view") { ok().build() }
        GET("/view") { ok().build() }
    }

    security {
        authenticationManager = repoAuthenticationManager

        http {
            authorizeRequests {
                authorize("/public-view", permitAll)
                authorize("/view", hasRole("USER"))
            }
            httpBasic {}
        }
    }
}
```