### PR TITLE
fix(jdbcDsl): make assignement of `isGenerateUniqueName` right

### DIFF
--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/jdbc/JdbcDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/jdbc/JdbcDsl.kt
@@ -39,7 +39,7 @@ class JdbcDsl(private val init: JdbcDsl.() -> Unit) : AbstractDsl() {
             name = this@JdbcDsl.name
             username = this@JdbcDsl.username
             password = this@JdbcDsl.password
-            generateUniqueName = this@JdbcDsl.generateUniqueName
+            isGenerateUniqueName = this@JdbcDsl.generateUniqueName
         }
 
         EmbeddedDataSourceConfigurationInitializer(dataSourceProperties).initialize(context)


### PR DESCRIPTION
The previous code was doing a self assignment. 