### PR TITLE
feat: Gradle set java target source compatibility for all projects

### DIFF
--- a/autoconfigure-adapter/build.gradle.kts
+++ b/autoconfigure-adapter/build.gradle.kts
@@ -3,11 +3,6 @@ plugins {
 	id("java-library")
 }
 
-java {
-	sourceCompatibility = JavaVersion.VERSION_1_8
-	targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
 	api("org.springframework.boot:spring-boot")
 	api("org.springframework.boot:spring-boot-autoconfigure")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,11 @@ allprojects {
 		useJUnitPlatform()
 	}
 
+	tasks.withType<JavaCompile> {
+		sourceCompatibility = "8"
+		targetCompatibility = "8"
+	}
+
 	tasks.withType<KotlinCompile> {
 		kotlinOptions {
 			jvmTarget = "1.8"

--- a/jafu/build.gradle.kts
+++ b/jafu/build.gradle.kts
@@ -3,11 +3,6 @@ plugins {
 	id("java-library")
 }
 
-tasks.compileJava {
-	sourceCompatibility = "8"
-	targetCompatibility = "8"
-}
-
 tasks.compileTestJava {
 	sourceCompatibility = "11"
 	targetCompatibility = "11"


### PR DESCRIPTION
Gradle infer target version of java [based on the used JDK](https://docs.gradle.org/current/userguide/upgrading_version_5.html#automatic_target_jvm_version) if not configured. It was the case for java projects but not for Kofu.

This PR set the target and source compatibility for java compilation on all projects

Should fix #338 