### PR TITLE
Kofu add enable configuration by ApplicationContextInitializer

### DIFF
--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/ConfigurationDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/ConfigurationDsl.kt
@@ -3,6 +3,7 @@ package org.springframework.fu.kofu
 import org.springframework.beans.BeanUtils
 import org.springframework.boot.context.properties.FunctionalConfigurationPropertiesBinder
 import org.springframework.boot.context.properties.bind.Bindable
+import org.springframework.context.ApplicationContextInitializer
 import org.springframework.context.ApplicationEvent
 import org.springframework.context.support.BeanDefinitionDsl
 import org.springframework.context.support.GenericApplicationContext
@@ -37,6 +38,15 @@ open class ConfigurationDsl(private val dsl: ConfigurationDsl.() -> Unit): Abstr
 	 * @sample org.springframework.fu.kofu.samples.applicationDslWithConfiguration
 	 */
 	fun enable(configuration: AbstractDsl) {
+		configuration.initialize(context)
+	}
+
+	/**
+	 * Enable the specified ApplicationContextInitializer.
+	 * @see configuration
+	 * @sample org.springframework.context.ApplicationContextInitializer
+	 */
+	fun enable(configuration: ApplicationContextInitializer<GenericApplicationContext>) {
 		configuration.initialize(context)
 	}
 

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/ConfigurationDslTest.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/ConfigurationDslTest.kt
@@ -1,0 +1,48 @@
+package org.springframework.fu.kofu
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.getBean
+import org.springframework.context.support.beans
+import org.springframework.fu.kofu.r2dbc.R2dbcDsl
+import org.springframework.r2dbc.core.DatabaseClient
+
+class ConfigurationDslTest {
+
+    @Test
+    fun `enable should initialize other AbstractDsl`() {
+        val r2dbc = R2dbcDsl {
+            url = "r2dbc:h2:mem:///testdb"
+        }
+
+        val app = application {
+            enable(r2dbc)
+        }
+        with(app.run()) {
+            val client = getBean<DatabaseClient>()
+            assertNotNull(client)
+            close()
+        }
+    }
+
+
+    @Test
+    fun `enable should initialize ApplicationContextInitializer`() {
+        val beans = beans {
+            bean<TestService>()
+            bean<TestHandler>()
+        }
+
+        val app = application {
+            enable(beans)
+        }
+        with(app.run()) {
+            getBean<TestService>()
+            getBean<TestHandler>()
+            close()
+        }
+    }
+
+    class TestService{}
+    class TestHandler(private val service: TestService)
+}


### PR DESCRIPTION
Add enable for ApplicationContextInitializer in Kofu ConfigurationDsl to match Jafu ConfigurationDsl.

This feature is already enabled in Jafu.

Fixes: #335 