### PR TITLE
DataR2dbc cleanup followup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,6 +151,19 @@ publishing {
 			})
 		}
 
+		create<MavenPublication>("kofu-reactive-data-r2dbc") {
+			groupId = "org.springframework.fu"
+			artifactId = "spring-fu-samples-kofu-reactive-data-r2dbc"
+			artifact(task<Zip>("kofuReactiveDataR2dbcSampleZip") {
+				from("samples/kofu-reactive-data-r2dbc") {
+					exclude("build", ".gradle", ".idea", "out", "*.iml")
+				}
+				destinationDirectory.set(file("$buildDir/dist"))
+				into("kofu-reactive-data-r2dbc")
+				setExecutablePermissions()
+			})
+		}
+
 		create<MavenPublication>("kofu-reactive-redis") {
 			groupId = "org.springframework.fu"
 			artifactId = "spring-fu-samples-kofu-reactive-redis"

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/r2dbc/DataR2dbcDslTest.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/r2dbc/DataR2dbcDslTest.kt
@@ -50,7 +50,7 @@ class DataR2dbcDslTest {
     }
 
     @Test
-    fun `enable data with postgres r2dbc`(@TempDir tempDir: Path) {
+    fun `enable data with postgres r2dbc`() {
         val pg = object : GenericContainer<Nothing>("postgres:13") {
             init {
                 withExposedPorts(5432)

--- a/samples/kofu-reactive-data-r2dbc/build.gradle.kts
+++ b/samples/kofu-reactive-data-r2dbc/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 dependencies {
-	implementation("org.springframework.fu:spring-fu-kofu:0.4.3-SNAPSHOT")
+	implementation("org.springframework.fu:spring-fu-kofu:0.5.0-SNAPSHOT")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springframework.boot:spring-boot-starter-mustache")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")


### PR DESCRIPTION
feat: Add kofu DataR2dbc sample publication
refacto: Clean a build warning in org.springframework.fu.kofu.r2dbc.DataR2dbcDslTest
fix: Update dependency for kofu-reactive-data-r2dbc to 0.5.0-SANPSHOT instead of old 0.4.3-SNAPSHOT