### PR TITLE
Initial implementation of ProjectInfo DSL

### DIFF
--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/info/ProjectInfoInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/info/ProjectInfoInitializer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.autoconfigure.info;
+
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+
+import java.util.function.Supplier;
+
+/**
+ * {@link ApplicationContextInitializer} adapter for {@link ProjectInfoAutoConfiguration}.
+ */
+public class ProjectInfoInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
+
+  private final ProjectInfoProperties properties;
+
+	public ProjectInfoInitializer(ProjectInfoProperties properties) { this.properties = properties;	}
+
+	@Override
+	public void initialize(GenericApplicationContext context) {
+    Supplier<ProjectInfoAutoConfiguration> projectInfoAutoConfigurationSupplier = new Supplier<ProjectInfoAutoConfiguration>() {
+
+      private ProjectInfoAutoConfiguration configuration;
+
+      @Override
+      public ProjectInfoAutoConfiguration get() {
+        if (configuration == null) {
+          configuration = new ProjectInfoAutoConfiguration(properties);
+        }
+        return configuration;
+      }
+    };
+
+		context.registerBean(BuildProperties.class, () -> {
+		  try {
+          return projectInfoAutoConfigurationSupplier.get().buildProperties();
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+      return null;
+    });
+
+		context.registerBean(GitProperties.class, () -> {
+      try {
+  		  return projectInfoAutoConfigurationSupplier.get().gitProperties();
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+      return null;
+    });
+	}
+}

--- a/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/info/ProjectInfoInitializer.java
+++ b/autoconfigure-adapter/src/main/java/org/springframework/boot/autoconfigure/info/ProjectInfoInitializer.java
@@ -30,10 +30,12 @@ public class ProjectInfoInitializer implements ApplicationContextInitializer<Gen
 
   private final ProjectInfoProperties properties;
 
-	public ProjectInfoInitializer(ProjectInfoProperties properties) { this.properties = properties;	}
+  public ProjectInfoInitializer(ProjectInfoProperties properties) {
+    this.properties = properties;
+  }
 
-	@Override
-	public void initialize(GenericApplicationContext context) {
+  @Override
+  public void initialize(GenericApplicationContext context) {
     Supplier<ProjectInfoAutoConfiguration> projectInfoAutoConfigurationSupplier = new Supplier<ProjectInfoAutoConfiguration>() {
 
       private ProjectInfoAutoConfiguration configuration;
@@ -47,22 +49,22 @@ public class ProjectInfoInitializer implements ApplicationContextInitializer<Gen
       }
     };
 
-		context.registerBean(BuildProperties.class, () -> {
-		  try {
-          return projectInfoAutoConfigurationSupplier.get().buildProperties();
+    context.registerBean(BuildProperties.class, () -> {
+      try {
+        return projectInfoAutoConfigurationSupplier.get().buildProperties();
       } catch (Exception e) {
         e.printStackTrace();
       }
       return null;
     });
 
-		context.registerBean(GitProperties.class, () -> {
+    context.registerBean(GitProperties.class, () -> {
       try {
-  		  return projectInfoAutoConfigurationSupplier.get().gitProperties();
+        return projectInfoAutoConfigurationSupplier.get().gitProperties();
       } catch (Exception e) {
         e.printStackTrace();
       }
       return null;
     });
-	}
+  }
 }

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/info/ProjectInfoDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/info/ProjectInfoDsl.kt
@@ -6,7 +6,7 @@ import org.springframework.context.support.GenericApplicationContext
 import org.springframework.fu.kofu.AbstractDsl
 import org.springframework.fu.kofu.ConfigurationDsl
 
-class ProjectInfoDsl(private val init: ProjectInfoDsl.() -> Unit, private val properties: ProjectInfoProperties) : AbstractDsl() {
+class ProjectInfoDsl(private val properties: ProjectInfoProperties, private val init: ProjectInfoDsl.() -> Unit) : AbstractDsl() {
 
     override fun initialize(context: GenericApplicationContext) {
         super.initialize(context)
@@ -20,5 +20,5 @@ class ProjectInfoDsl(private val init: ProjectInfoDsl.() -> Unit, private val pr
  * @see ProjectInfoDsl
  */
 fun ConfigurationDsl.projectInfo(projectInfoDsl: ProjectInfoDsl.() -> Unit = {}) {
-    ProjectInfoDsl(projectInfoDsl, configurationProperties(prefix = "spring.info")).initialize(context)
+    ProjectInfoDsl(configurationProperties(prefix = "spring.info"), projectInfoDsl).initialize(context)
 }

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/info/ProjectInfoDsl.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/info/ProjectInfoDsl.kt
@@ -1,0 +1,24 @@
+package org.springframework.fu.kofu.info
+
+import org.springframework.boot.autoconfigure.info.ProjectInfoInitializer
+import org.springframework.boot.autoconfigure.info.ProjectInfoProperties
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.fu.kofu.AbstractDsl
+import org.springframework.fu.kofu.ConfigurationDsl
+
+class ProjectInfoDsl(private val init: ProjectInfoDsl.() -> Unit, private val properties: ProjectInfoProperties) : AbstractDsl() {
+
+    override fun initialize(context: GenericApplicationContext) {
+        super.initialize(context)
+        init()
+        ProjectInfoInitializer(properties).initialize(context)
+    }
+}
+
+/**
+ * Configure ProjectInfo support.
+ * @see ProjectInfoDsl
+ */
+fun ConfigurationDsl.projectInfo(projectInfoDsl: ProjectInfoDsl.() -> Unit = {}) {
+    ProjectInfoDsl(projectInfoDsl, configurationProperties(prefix = "spring.info")).initialize(context)
+}


### PR DESCRIPTION
to expose `BuildProperties` and `GitProperties` beans. 

Appears to work well BUT I was not able to incorporate the conditional checks, they are implemented as `SpringBootCondition`s, I'm not sure if it's possible to get a reference to `ConditionContext`? Is there a strategy for doing this? Would very much like to avoid reimplementing the same conditions in spring-fu. 