### PR TITLE
Hybrid Application

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kofu/build.gradle.kts
+++ b/kofu/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 
 	testImplementation("org.junit.jupiter:junit-jupiter-api")
 	testImplementation("org.springframework:spring-test")
+	testImplementation("org.springframework.boot:spring-boot-test")
 	testImplementation("io.projectreactor:reactor-test")
 	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 	testImplementation("org.springframework.boot:spring-boot-starter-web")

--- a/kofu/src/main/kotlin/org/springframework/fu/kofu/KofuHybridApplication.kt
+++ b/kofu/src/main/kotlin/org/springframework/fu/kofu/KofuHybridApplication.kt
@@ -1,0 +1,26 @@
+package org.springframework.fu.kofu
+
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.core.Ordered
+
+
+/**
+ * Kofu application that supports annotation configuration as well
+ * To use, declare a class that extends this class,
+ * and register that class in your application's spring.factories file as a ApplicationContextInitializer.
+ * This class may be your main Application class, but that is optional.
+ * @author John Burns
+ */
+abstract class KofuHybridApplication : Ordered, ApplicationContextInitializer<GenericApplicationContext> {
+    abstract fun dslConfigure(): ApplicationDsl.() -> Unit
+
+    override fun getOrder(): Int {
+        return Int.MIN_VALUE
+    }
+
+    override fun initialize(applicationContext: GenericApplicationContext) {
+        val app = ApplicationDsl(dslConfigure())
+        app.toInitializer().initialize(applicationContext)
+    }
+}

--- a/kofu/src/test/kotlin/org/springframework/fu/kofu/KofuHybridApplicationTest.kt
+++ b/kofu/src/test/kotlin/org/springframework/fu/kofu/KofuHybridApplicationTest.kt
@@ -1,0 +1,78 @@
+package org.springframework.fu.kofu
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration
+import org.springframework.boot.autoconfigure.data.cassandra.CassandraDataAutoConfiguration
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.context.support.registerBean
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.web.servlet.config.annotation.EnableWebMvc
+
+@SpringBootTest(classes = [TestApplication::class])
+@ContextConfiguration(initializers = [TestApplication::class])
+class KofuHybridApplicationTest {
+    @Autowired
+    lateinit var configuredBean: ConfiguredBean
+
+    @Autowired
+    lateinit var dsl: DslBean
+
+    @Test
+    fun test() {
+        assertEquals("test", configuredBean.value)
+        assertEquals("value", dsl.value)
+    }
+}
+
+@SpringBootConfiguration
+@EnableAutoConfiguration(
+    exclude = [
+        CassandraDataAutoConfiguration::class,
+        CassandraAutoConfiguration::class,
+        MongoAutoConfiguration::class,
+        EmbeddedMongoAutoConfiguration::class
+    ]
+)
+@EnableWebMvc
+open class TestApplication : KofuHybridApplication() {
+    override fun dslConfigure(): ApplicationDsl.() -> Unit = {
+        beans {
+            bean<ConfiguredBean>("aBean") {
+                ConfiguredBean("test")
+            }
+        }
+        custom {
+            enable()
+        }
+    }
+
+}
+
+@KofuMarker
+fun ApplicationDsl.custom(config: CustomDsl.() -> Unit) {
+    enable(CustomDsl().apply(config))
+}
+
+@KofuMarker
+class CustomDsl : AbstractDsl() {
+    private var enabled: Boolean = false
+    fun enable() {
+        enabled = true
+    }
+
+    override fun initialize(context: GenericApplicationContext) {
+        context.registerBean<DslBean>("dsl", { }) {
+            DslBean("value")
+        }
+    }
+}
+
+class DslBean(val value: String)
+class ConfiguredBean(val value: String)


### PR DESCRIPTION
update gradle
Introduce "hybrid" applications which allow kofu to be mixed with a traditional annotation context. This will assist codebases to migrate gradually, and/or still use boot libraries that don't support kofu